### PR TITLE
Update Dockerfile to simplify setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,21 +35,21 @@ build-container: check-requirements ## Build docker container.
 
 config: check-requirements ## Generate configuration.
 	@echo "\nGenerate configuration..\n" && \
-	${DOCKER_CMD} run --rm --name DM-config -v ${source_dir}:/app/src -v ${artifact_dir}:/app/things -v ${config_dir}:/app/configs dactyl-keyboard python3 -i generate_configuration.py && \
+	${DOCKER_CMD} run --rm --name DM-config -v ${source_dir}:/app/src -v ${artifact_dir}:/app/things -v ${config_dir}:/app/configs dactyl-keyboard python3 -i src/generate_configuration.py && \
 	echo "Done"
 .PHONY: config
 
 build-models: check-requirements ## Build models.
 	@echo "\nGenerate configured model..\n" && \
 	cd ${current_dir} && \
-	${DOCKER_CMD} run --rm --name DM-run -v ${source_dir}:/app/src -v ${artifact_dir}:/app/things -v ${config_dir}:/app/configs dactyl-keyboard python3 -i dactyl_manuform.py && \
+	${DOCKER_CMD} run --rm --name DM-run -v ${source_dir}:/app/src -v ${artifact_dir}:/app/things -v ${config_dir}:/app/configs dactyl-keyboard python3 -i src/dactyl_manuform.py && \
 	echo "Done"
 .PHONY: config
 
 build-models: check-requirements ## Build models.
 	@echo "\nGenerate release models..\n" && \
 	cd ${current_dir} && \
-	${DOCKER_CMD} run --rm --name DM-release-build -v ${source_dir}:/app/src -v ${artifact_dir}:/app/things -v ${config_dir}:/app/configs dactyl-keyboard python3 -i model_builder.py && \
+	${DOCKER_CMD} run --rm --name DM-release-build -v ${source_dir}:/app/src -v ${artifact_dir}:/app/things -v ${config_dir}:/app/configs dactyl-keyboard python3 -i src/model_builder.py && \
 	echo "Done"
 .PHONY: config
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,18 +1,14 @@
-FROM mambaorg/micromamba:0.8.2
+FROM python:3.10.8-slim-bullseye
 
-RUN apt-get update && \
-    apt-get install -y libgl1-mesa-glx gcc bash && \
-    rm -rf /var/lib/apt/lists/*
+RUN apt update && \
+    apt install -y git
+
+RUN pip install \
+        cadquery-ocp==7.6.3a0 \
+        git+https://github.com/CadQuery/cadquery.git \
+        dataclasses-json \
+        numpy \
+        scipy \
+        solidpython
 
 WORKDIR /app
-RUN micromamba install -y -n base -c conda-forge -c cadquery \
-    python=3 \
-    cadquery=master \
-    numpy=1 \
-    scipy=1 && \
-    (rm /opt/conda/pkgs/cache/* || true)
-
-RUN pip3 install solidpython
-
-
-WORKDIR /app/src

--- a/src/generate_configuration.py
+++ b/src/generate_configuration.py
@@ -25,6 +25,7 @@ shape_config = {
     "logo_file": None,
     'show_caps': True,
     'show_pcbs': False, #only runs if caps are shown, easist place to initially inject geometry
+    'resin': False,
 
     'nrows':  5, #5,  # key rows
     'ncols':  6, #6,  # key columns


### PR DESCRIPTION
- Update Dockerfile to use vanilla `python` image with `pip`
- Set the working dir to `/app` (because code in `dactyl_manuform.py` makes reference to `run_config.json` in the `src` folder)
- Add `'resin': False` to `generate_configuration.py` to be on par with `run_config.json`

I'm not sure why there are two `build-models` targets in `Makefile`, so it is possible that I haven't tested all the ways you call the code.

Cheers!