### PR TITLE
Fix cadquery dependencies in conda.sh

### DIFF
--- a/conda.sh
+++ b/conda.sh
@@ -51,7 +51,7 @@ conda activate $envName
 
 inform "Installing CadQuery..."
 
-conda install -c conda-forge -c cadquery cadquery=master -y
+conda install -c conda-forge cadquery occt=7.7.0 -y
 
 inform "Installing dataclasses-json..."
 


### PR DESCRIPTION
# What's in this PR?
This PR fixes an issue when trying to use the `cadquery` engine.

### Why was this PR created?
Fix for issue https://github.com/bullwinkle3000/dactyl-keyboard/issues/12

### Quick summary of the changes you made
- Changed the `conda install cadquery` instruction to specify `occt=7.7.0`
